### PR TITLE
Refactor sdk and cli.

### DIFF
--- a/src/pasteme_cli/__main__.py
+++ b/src/pasteme_cli/__main__.py
@@ -1,5 +1,5 @@
 """
-Entrypoint module, in case you use `python -mpasteme_cli`.
+Entrypoint module, in case you use `python -m pasteme_cli`.
 
 
 Why does this file exist, and why __main__? For more info, read:
@@ -8,7 +8,7 @@ Why does this file exist, and why __main__? For more info, read:
 - https://docs.python.org/2/using/cmdline.html#cmdoption-m
 - https://docs.python.org/3/using/cmdline.html#cmdoption-m
 """
-from pasteme_cli.cli import main
+from .cli import main
 
 if __name__ == "__main__":
     main()

--- a/src/pasteme_cli/cli.py
+++ b/src/pasteme_cli/cli.py
@@ -34,7 +34,7 @@ from .constants import (
 from .sdk import PasteMe
 
 parser = argparse.ArgumentParser(
-    description=('A CLI pastebin tool interacting with PasteMe ' f'({PASTEME_SERVICE_URL}) RESTful APIs.'),
+    description=f'A CLI pastebin tool interacting with PasteMe ({PASTEME_SERVICE_URL}) RESTful APIs.',
     epilog=EPILOG_DESCRIPTION,
     formatter_class=argparse.RawDescriptionHelpFormatter,
 )

--- a/src/pasteme_cli/cli.py
+++ b/src/pasteme_cli/cli.py
@@ -6,7 +6,7 @@ Why does this file exist, and why not put this in __main__?
   You might be tempted to import things from __main__ later, but that will cause
   problems: the code will get executed twice:
 
-  - When you run `python -mpasteme_cli` python will execute
+  - When you run `python -m pasteme_cli` python will execute
     ``__main__.py`` as a script. That means there won't be any
     ``pasteme_cli.__main__`` in ``sys.modules``.
   - When you import __main__ it will get executed again (as a module) because
@@ -16,10 +16,9 @@ Why does this file exist, and why not put this in __main__?
 """
 import argparse
 import sys
+from typing import Optional, Sequence
 
 from requests.exceptions import ConnectionError
-
-from pasteme_cli.sdk import Snippet
 
 from .constants import (
     CONNECTION_ISSUE_HINT,
@@ -28,14 +27,14 @@ from .constants import (
     EXPIRY_TIME_HINT,
     LANGUAGES,
     LANGUAGES_HINT,
-    PASTEME_API_URL,
     PASTEME_SERVICE_URL,
     THEMES,
     THEMES_HINT,
 )
+from .sdk import PasteMe
 
 parser = argparse.ArgumentParser(
-    description=f'A CLI pastebin tool interacting with PasteMe ({PASTEME_SERVICE_URL}) RESTful APIs.',
+    description=('A CLI pastebin tool interacting with PasteMe ' f'({PASTEME_SERVICE_URL}) RESTful APIs.'),
     epilog=EPILOG_DESCRIPTION,
     formatter_class=argparse.RawDescriptionHelpFormatter,
 )
@@ -101,13 +100,13 @@ parser.add_argument(
 )
 
 
-def main(args=None):
+def main(args: Optional[Sequence[str]] = None) -> None:
     args = parser.parse_args(args=args)
 
     with args.file as source_code:
         code_lines = source_code.readlines()
 
-    args.end = args.end if args.end else len(code_lines)
+    args.end = args.end or len(code_lines)
 
     code_lines = code_lines[int(args.start) - 1 : int(args.end)]
 
@@ -120,18 +119,16 @@ def main(args=None):
         "1m": 30,
     }
 
-    context = {
-        'title': args.title,
-        'body': ''.join(code_lines),
-        'language': args.language,
-        'theme': args.theme,
-        'expiry_time': expiry_days[args.expiry_time],
-    }
-
     try:
-        snippet = Snippet(**context)
-        context = snippet.push(PASTEME_API_URL, args.verbose).json()
-        print(f'PASTE --> {context["url"]}')
+        snippet = PasteMe(args.verbose)
+        resp = snippet.create(
+            title=args.title,
+            body=''.join(code_lines),
+            language=args.language,
+            theme=args.theme,
+            expiry_time=expiry_days[args.expiry_time],
+        )
+        print(f'PASTE --> {resp.url}')
         sys.exit()
     except ConnectionError:
         sys.exit(CONNECTION_ISSUE_HINT)

--- a/src/pasteme_cli/constants.py
+++ b/src/pasteme_cli/constants.py
@@ -35,24 +35,22 @@ EXPIRY_TIME = {
 
 # Hint for using the available languages
 LANGUAGES_HINT = f'''snippet language (available languages:
-{", ".join([_ for _ in LANGUAGES.keys()])})
+{", ".join(LANGUAGES.keys())})
 '''
 
 # Hint for using the available themes
 THEMES_HINT = f'''theme (available themes:
-{", ".join([_ for _ in THEMES.keys()])})
+{", ".join(THEMES.keys())})
 '''
 
 # Hint for using the available expiry times
 EXPIRY_TIME_HINT = f'''expiry time (available expiry times:
-{", ".join([_ for _ in EXPIRY_TIME.keys()])}) (default: 1w/1week)
+{", ".join(EXPIRY_TIME.keys())}) (default: 1w/1week)
 '''
 
 # Actual service information
 
 PASTEME_SERVICE_URL = 'https://pasteme.pythonanywhere.com'
-
-PASTEME_API_URL = 'https://pasteme.pythonanywhere.com/api/v1/paste/'
 
 # Traceback messages
 

--- a/src/pasteme_cli/sdk/__init__.py
+++ b/src/pasteme_cli/sdk/__init__.py
@@ -1,3 +1,5 @@
-from .pasteme import Snippet
+from .pasteme import PasteMe
 
-__all__ = ("Snippet",)
+__all__ = [
+    "PasteMe",
+]

--- a/src/pasteme_cli/sdk/pasteme.py
+++ b/src/pasteme_cli/sdk/pasteme.py
@@ -1,30 +1,40 @@
 import json
+from typing import ClassVar
+from urllib.parse import urljoin
 
 import requests
 from pygments import formatters, highlight, lexers
+
+from ..constants import PASTEME_SERVICE_URL
+from .types import APIResponse
 
 JSON_TEMPLATE = '''-> {}
 {}'''
 
 
-class Snippet:
-    def __init__(self, title, body, language, theme, expiry_time) -> None:
-        self.snippet = {
-            'title': title,
-            'body': body,
-            'language': language,
-            'theme': theme,
-            'expires_in': expiry_time,
-        }
+class PasteMe:
+    BASE_URL: ClassVar[str] = PASTEME_SERVICE_URL
+    API_URL: ClassVar[str] = urljoin(BASE_URL, "/api/v1/paste/")
 
-    def push(self, url, is_verbose=False) -> requests.Response:
-        response = requests.post(url=url, data=self.snippet)
+    def __init__(self, verbose: bool = False) -> None:
+        self.verbose = verbose
 
-        if is_verbose:
+    def create(self, **context) -> APIResponse:
+        response = requests.post(self.API_URL, data=context)
+
+        if self.verbose:
             response_json = response.json()
-            sent_data = highlight(json.dumps(self.snippet, indent=3), lexers.JsonLexer(), formatters.TerminalFormatter())
-            response_data = highlight(json.dumps(response_json, indent=3), lexers.JsonLexer(), formatters.TerminalFormatter())
+            sent_data = highlight(
+                json.dumps(context, indent=3),
+                lexers.JsonLexer(),
+                formatters.TerminalFormatter(),
+            )
+            response_data = highlight(
+                json.dumps(response_json, indent=3),
+                lexers.JsonLexer(),
+                formatters.TerminalFormatter(),
+            )
             print(JSON_TEMPLATE.format('Posted Data', sent_data))
             print(JSON_TEMPLATE.format('Returned Payload', response_data))
 
-        return response
+        return APIResponse(**response.json())

--- a/src/pasteme_cli/sdk/types.py
+++ b/src/pasteme_cli/sdk/types.py
@@ -1,0 +1,13 @@
+"""Types representing API responses from PasteMe."""
+from dataclasses import dataclass
+
+
+@dataclass
+class APIResponse:
+    id: str
+    title: str
+    body: str
+    language: str
+    theme: str
+    expires_in: str
+    url: str

--- a/tests/test_snippet.py
+++ b/tests/test_snippet.py
@@ -1,7 +1,7 @@
 import unittest
 
-from pasteme_cli.constants import PASTEME_API_URL
-from pasteme_cli.sdk.pasteme import Snippet
+from src.pasteme_cli.constants import PASTEME_SERVICE_URL
+from src.pasteme_cli.sdk.pasteme import PasteMe
 
 
 class SnippetTestCase(unittest.TestCase):
@@ -16,9 +16,8 @@ class SnippetTestCase(unittest.TestCase):
 
     # TODO: Using mocks
     def test_push_snippet(self):
-        response = Snippet(**self.sample).push(PASTEME_API_URL)
-        self.assertEqual(response.status_code, 201)
-        self.assertIn('url', response.json().keys())
+        resp = PasteMe().create(**self.sample)
+        self.assertIn(PASTEME_SERVICE_URL, resp.url)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Change Summary

- Remove redundant _list comprehensions_ from constants since the `str.join()` method takes an `Iterable` as first argument and `dict.keys()` also returns a set-like object, therefore it's iterable!

For example this 

```python
THEMES_HINT = f'''theme (available themes:
{", ".join([_ for _ in THEMES.keys()])})
'''
```

will become this

```python
THEMES_HINT = f'''theme (available themes:
{", ".join(THEMES.keys())})
'''
```

- Fix a typo in module docs:

`python -mpasteme_cli` corrected to `python -m pasteme_cli`

- Add type annotations for methods and functions.
- Turn `Snippet` class into a more concise and user friendly interface with more meaningful method names and instance attributes.
- Add new types to represent responses from PasteMe API and give users a pythonic way of accessing response parameters using the dot notation. e.g:

```python
from pasteme_cli.sdk import PasteMe

context = {
    "title": "My Snippet",
    ...
}

snippet = PasteMe(verbose=True).create(**context)
print(snippet.url)
```

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have written/changed corresponding tests for new implementations.